### PR TITLE
Update README.md to reflect correct GDEX references and example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dsglobus
 
 This application is a command-line tool for Globus data transfer and management of files 
-archived in the NSF NCAR Research Data Archive.
+archived in the [NSF NCAR Geoscience Data Exchange (GDEX)](https://gdex.ucar.edu).
 
 ## Installation
 
@@ -24,6 +24,7 @@ The `dsglobus` app is run with the following subcommands.  Each supports a
 dsglobus transfer --help
 dsglobus get-task --help
 dsglobus task-list --help
+dsglobus task-event-list --help
 dsglobus cancel-task --help
 dsglobus ls --help
 dsglobus mkdir --help
@@ -32,12 +33,12 @@ dsglobus delete --help
 ```
 
 ### Example usage
-1. Transfer a single file from the `NCAR RDA GLADE` endpoint to the `NCAR RDA Quasar`
+1. Transfer a single file from the `NCAR GDEX GLADE` endpoint to the `NCAR GDEX Quasar`
 endpoint:
 ```
 $ dsglobus transfer \
-    --source-endpoint rda-glade \
-    --destination-endpoint rda-quasar \
+    --source-endpoint gdex-glade \
+    --destination-endpoint gdex-quasar \
     --source-file /data/d999009/file.txt \
     --destination-file /d999009/file.txt
 ```


### PR DESCRIPTION
This pull request updates the documentation for the `dsglobus` command-line tool to reflect the transition from the NSF NCAR Research Data Archive (RDA) to the NSF NCAR Geoscience Data Exchange (GDEX), and adds information about a new subcommand. The changes ensure that users have accurate and up-to-date instructions for using the tool with GDEX endpoints and are aware of all supported subcommands.

Documentation updates:

* Updated references throughout `README.md` from "NSF NCAR Research Data Archive" and "RDA" endpoints to "NSF NCAR Geoscience Data Exchange (GDEX)" and "GDEX" endpoints, including example usage and endpoint names. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R41)
* Added the `dsglobus task-event-list --help` subcommand to the list of supported commands in the usage section.